### PR TITLE
removes spacing in job certificate

### DIFF
--- a/chart/ibm-masapp-kafka/scripts/job.sh
+++ b/chart/ibm-masapp-kafka/scripts/job.sh
@@ -41,6 +41,6 @@ spec:
   certificates:
     - alias: ${CLUSTERID}-ca
       crt: |
-$(echo | awk -v ca_var="$bootcert" '{ printf ca_var; }' | sed 's/^/        /')  
+$(echo | awk -v ca_var="$bootcert" '{ printf ca_var; }' | sed 's/^/        /')
 EOL
 oc apply -f ./cfgjob.yaml -n ${CORENAMESPACE}


### PR DESCRIPTION
found during testing with iot app, possible issue with spacing of cert that is valid in config but is causing SBO to add extra spacing